### PR TITLE
[Latex] Remove unnecessary parse

### DIFF
--- a/latex/module.py
+++ b/latex/module.py
@@ -1,7 +1,5 @@
 import io
 import re
-import urllib
-import urllib.parse
 
 import aiohttp
 
@@ -24,7 +22,6 @@ class Latex(commands.Cog):
     @check.acl2(check.ACLevel.MEMBER)
     @commands.command()
     async def latex(self, ctx: commands.Context, *, equation: str):
-        equation: str = urllib.parse.quote(equation)
         base_url: str = "https://www.sciweavers.org/"
         payload = {
             "eq_latex": equation,


### PR DESCRIPTION
Urllib parse caused trouble - equations were shortened